### PR TITLE
Enable openblas on windows.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,12 +3,31 @@
 
 echo on
 
+if "%blas_impl%"=="openblas" (
+    set "SS_BLAS=-DBLA_VENDOR=OpenBLAS"
+) else if "%blas_impl%"=="mkl" (
+    set "SS_BLAS=-DBLA_VENDOR=Intel10_64lp"
+) else (
+    echo ERROR: blas_impl must be openblas or mkl, got "%blas_impl%"
+    exit 1
+)
+
+:: flang on Windows uses lowercase-no-underscore naming (dgemm), but OpenBLAS
+:: exports lowercase-with-underscore (dgemm_).  Override the Fortran symbol
+:: convention via an initial-cache file.  The echo lines with parentheses must
+:: be at the top level so cmd.exe does not mangle them.  See SuiteSparse #765.
+echo set(SUITESPARSE_USE_FORTRAN OFF CACHE BOOL "" FORCE)> "%SRC_DIR%\ss_blas.cmake"
+if "%blas_impl%"=="openblas" echo set(SUITESPARSE_C_TO_FORTRAN "(name,NAME) name##_" CACHE STRING "" FORCE)>> "%SRC_DIR%\ss_blas.cmake"
+if "%blas_impl%"=="mkl" echo set(SUITESPARSE_C_TO_FORTRAN "(name,NAME) NAME" CACHE STRING "" FORCE)>> "%SRC_DIR%\ss_blas.cmake"
+
 :: Skip LAGraph, GraphBLAS, and Mongoose.
 FOR %%G IN (SuiteSparse_config,AMD,BTF,CAMD,CCOLAMD,COLAMD,CHOLMOD,CSparse,CXSparse,LDL,KLU,UMFPACK,ParU,RBio,SPQR,SPEX) DO (
-    pushd %%G\\build
+    pushd %%G\build
     if errorlevel 1 exit 1
     cmake -G "Ninja" ^
           %CMAKE_ARGS% ^
+          %SS_BLAS% ^
+          -C "%SRC_DIR%\ss_blas.cmake" ^
           -DBUILD_SHARED_LIBS=ON ^
           -DBUILD_STATIC_LIBS=ON ^
           -DCMAKE_BUILD_TYPE:STRING=Release ^

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,11 @@
 mkl:
   - 2025
+
+blas_impl:
+  - mkl                        # [(x86 or x86_64) and not osx]
+  - openblas
+
+fortran_compiler:
+  - flang             # [win]
+fortran_compiler_version:
+  - 20                # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
     sha256: ce39b28d4038a09c14f21e02c664401be73c0cb96a9198418d6a98a7db73a259
 
 build:
-  number: 0
+  number: 1
   skip: True  # [s390x]
   run_exports:
     - {{ pin_subpackage("suitesparse") }}


### PR DESCRIPTION
suitesparse rebuild with openblas windows variant

**Destination** channel: defaults

### Explanation of changes:
- add openblas to build matrix for windows and override fortran compiler to flang. Can be removed once https://github.com/AnacondaRecipes/aggregate/pull/438 is available.
- Bump build number
- Set SUITESPARSE_C_TO_FORTRAN as described upstream: https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/dev/README.md?plain=1#L1119

https://anaconda.atlassian.net/browse/PKG-13575